### PR TITLE
ci(workflow): update version extraction command in tag-on-merge workflow

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: '23.6.x'
       - name: Read version from package.json
         id: get_version
-        run: echo "VERSION=$(node -p \\"require('./package.json').version\\")" >> $GITHUB_ENV
+        run: echo "VERSION=$(node -p 'require(`./package.json`).version')" >> $GITHUB_ENV
       - name: Create tag
         run: |
           git config user.name "GitHub Actions"


### PR DESCRIPTION
- Replace double quotes with backticks in node command for version extraction
- Improve reliability of package.json parsing in CI environment