### PR TITLE
ci: update GitHub token for tag creation

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "VERSION=$(node -p 'require(`./package.json`).version')" >> $GITHUB_ENV
       - name: Create tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
           git config user.name "gibsfinancedev"
           git config user.email "162373480+gibsfinancedev@users.noreply.github.com"


### PR DESCRIPTION
Replace GITHUB_TOKEN with PAT in tag-on-merge workflow

This change ensures that the tag creation process uses a Personal Access Token (PAT) instead of the default GITHUB_TOKEN for better permissions handling.